### PR TITLE
Merge fix/empty-crud-body-checking into main

### DIFF
--- a/src/Controller/AbstractApiController.php
+++ b/src/Controller/AbstractApiController.php
@@ -294,7 +294,7 @@
 			return [];
 		}
 
-		private function checkPayloadInstanceNotNull(?object $data): bool {
+		protected function checkPayloadInstanceNotNull(?object $data): bool {
 			if ($data === null)
 				throw new NullPayloadException();
 

--- a/src/Error/Errors/Controller/EmptyPayloadError.php
+++ b/src/Error/Errors/Controller/EmptyPayloadError.php
@@ -1,0 +1,10 @@
+<?php
+	namespace DaybreakStudios\Rest\Error\Errors\Controller;
+
+	use DaybreakStudios\Rest\Error\ApiError;
+
+	class EmptyPayloadError extends ApiError {
+		public function __construct() {
+			parent::__construct('controller.empty_payload', 'Your request must include a body');
+		}
+	}

--- a/src/Event/Listeners/Controller/PayloadInitListener.php
+++ b/src/Event/Listeners/Controller/PayloadInitListener.php
@@ -1,6 +1,7 @@
 <?php
 	namespace DaybreakStudios\Rest\Event\Listeners\Controller;
 
+	use DaybreakStudios\Rest\Error\Errors\Controller\EmptyPayloadError;
 	use DaybreakStudios\Rest\Event\Events\Controller\PayloadInitEvent;
 	use DaybreakStudios\Rest\Event\Events\DefaultRequestFormatEvent;
 	use DaybreakStudios\Rest\Event\Listeners\DefaultRequestFormatProvider;
@@ -27,8 +28,10 @@
 			$request = $this->requestStack->getCurrentRequest();
 			$content = $this->getRawPayloadFromRequest($request);
 
-			if ($content === null)
+			if ($content === null) {
+				$event->setError(new EmptyPayloadError());
 				return;
+			}
 
 			try {
 				$instance = $this->serializer->deserialize(


### PR DESCRIPTION
## What's Changed
- #1: `PayloadInitListener` now sets an `EmptyPayloadError` if the request does not have a body.